### PR TITLE
#165165474 Create user roles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1080,6 +1080,25 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,19 @@
     "start": "node ./build/index.js",
     "start:dev": "nodemon --exec babel-node ./src/index.js",
     "build": "babel -d build/ src",
-    "test": "NODE_ENV=test nyc mocha --exit --timeout 100000 --require @babel/register ./tests/*",
+    "test": "NODE_ENV=test npm run db:unmigrate && NODE_ENV=test npm run db:migrate && NODE_ENV=test npm run db:seed && NODE_ENV=test nyc mocha --exit --timeout 100000 --require @babel/register ./tests/*",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "db:migrate": "sequelize db:migrate",
     "db:unmigrate": "sequelize db:migrate:undo:all",
     "db:seed": "sequelize db:seed:all"
+  },
+  "nyc": {
+    "exclude": [
+      "tests",
+      "src/db/models/index.js"
+    ]
   },
   "repository": {
     "type": "git",
@@ -27,6 +33,7 @@
   },
   "homepage": "https://github.com/daniellamarr/selfless-service-backend#readme",
   "dependencies": {
+    "body-parser": "^1.18.3",
     "dotenv": "^7.0.0",
     "express": "^4.16.4",
     "pg": "^7.9.0",
@@ -39,6 +46,7 @@
     "@babel/node": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
     "@babel/register": "^7.0.0",
+    "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
     "chai-http": "^4.2.1",
     "coveralls": "^3.0.3",

--- a/src/controllers/RolesController.js
+++ b/src/controllers/RolesController.js
@@ -1,0 +1,44 @@
+import models from '../db/models';
+import Response from '../helpers/Response';
+
+const { Role } = models;
+
+/**
+ * Class Roles Controller
+ */
+class RolesController {
+  /**
+   * Creates a new user role
+   * @param {object} req request object for create function
+   * @param {object} res response object for create function
+   * @returns {object} new role created
+   */
+  static async create(req, res) {
+    const { title } = req.body;
+
+    const createRole = await Role.findOrCreate({
+      where: {
+        title
+      },
+      attributes: ['id', 'title']
+    });
+
+    if (!createRole[1]) {
+      const response = new Response(
+        'Bad Request',
+        400,
+        'This role already exists'
+      );
+      return res.status(response.code).json(response);
+    }
+
+    const response = new Response(
+      'Created',
+      201,
+      'Role created'
+    );
+    return res.status(response.code).json(response);
+  }
+}
+
+export default RolesController;

--- a/src/db/migrations/20190407122511-create-role.js
+++ b/src/db/migrations/20190407122511-create-role.js
@@ -1,0 +1,23 @@
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Roles', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    title: {
+      type: Sequelize.STRING
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('Roles')
+};

--- a/src/db/models/role.js
+++ b/src/db/models/role.js
@@ -1,0 +1,10 @@
+
+module.exports = (sequelize, DataTypes) => {
+  const Role = sequelize.define('Role', {
+    title: DataTypes.STRING
+  }, {});
+  Role.associate = function (models) {
+    // associations can be defined here
+  };
+  return Role;
+};

--- a/src/db/seeders/20190407143133-create-default-user-roles.js
+++ b/src/db/seeders/20190407143133-create-default-user-roles.js
@@ -1,0 +1,16 @@
+module.exports = {
+  up: queryInterface => queryInterface.bulkInsert('Roles', [
+    {
+      title: 'Admin',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      title: 'User',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+  ], {}),
+
+  down: queryInterface => queryInterface.bulkDelete('Roles', null, {})
+};

--- a/src/helpers/Response.js
+++ b/src/helpers/Response.js
@@ -1,0 +1,18 @@
+/**
+ * Class Response
+ */
+export default class Response {
+  /**
+   * Response Helper Class
+   * @param {string} status response text
+   * @param {number} code response code
+   * @param {string} message additional response description
+   * @param {object} data response object data
+   */
+  constructor(status, code, message, data) {
+    this.status = status;
+    this.code = code;
+    this.message = message;
+    this.data = data;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,16 @@
+/* eslint-disable import/prefer-default-export */
 import express from 'express';
+import bodyParser from 'body-parser';
+import routes from './routes';
 
 const server = express();
 
-const port = 2400 || process.env.PORT;
+server.use(bodyParser.urlencoded({ extended: false }));
+server.use(bodyParser.json());
+server.use('/api/v1', routes);
+
+const port = process.env.PORT || 2400;
 
 server.listen(port);
+
+export { server };

--- a/src/middlewares/RolesMiddleware.js
+++ b/src/middlewares/RolesMiddleware.js
@@ -1,0 +1,30 @@
+import Response from '../helpers/Response';
+
+/**
+ * Class RoleMiddleware
+ */
+class RolesMiddleware {
+  /**
+   * Verifies a role before being created
+   * @param {object} req request object for create function
+   * @param {object} res response object for create function
+   * @param {function} next
+   * @returns {object} error object
+   */
+  static verifyCreate(req, res, next) {
+    const { title } = req.body;
+
+    if (!title) {
+      const response = new Response(
+        'Bad Request',
+        400,
+        'The title field cannot be empty'
+      );
+      return res.status(response.code).json(response);
+    }
+
+    next();
+  }
+}
+
+export default RolesMiddleware;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import rolesRouter from './rolesRouter';
+
+const routes = express.Router();
+
+routes.use('/roles', rolesRouter);
+
+export default routes;

--- a/src/routes/rolesRouter.js
+++ b/src/routes/rolesRouter.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import RolesController from '../controllers/RolesController';
+import RolesMiddleware from '../middlewares/RolesMiddleware';
+
+const rolesRouter = express.Router();
+
+rolesRouter.post(
+  '/create',
+  RolesMiddleware.verifyCreate,
+  RolesController.create
+);
+
+export default rolesRouter;

--- a/tests/controllers/roles.spec.js
+++ b/tests/controllers/roles.spec.js
@@ -1,0 +1,54 @@
+import 'babel-polyfill';
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { server } from '../../src/index';
+import {
+  mockCreateRole,
+  mockRoleWithoutTitleField,
+  mockAlreadyExistingRole
+} from '../mocks/roles.mock';
+
+chai.use(chaiHttp);
+const { expect } = chai;
+
+const testPath = '/api/v1/roles/';
+
+describe('Roles Endpoints test', () => {
+  describe('/POST Request', () => {
+    it('should create a user role', (done) => {
+      chai.request(server)
+        .post(`${testPath}create`)
+        .send(mockCreateRole)
+        .end((err, res) => {
+          expect(res.body).to.be.a('object');
+          expect(res.status).to.equal(201);
+          expect(res.body.message).to.equal('Role created');
+          done(err);
+        });
+    });
+
+    it('should not create a role when title field is empty', (done) => {
+      chai.request(server)
+        .post(`${testPath}create`)
+        .send(mockRoleWithoutTitleField)
+        .end((err, res) => {
+          expect(res.body).to.be.a('object');
+          expect(res.status).to.equal(400);
+          expect(res.body.message).to.equal('The title field cannot be empty');
+          done(err);
+        });
+    });
+
+    it('should not create a role when that role already exists', (done) => {
+      chai.request(server)
+        .post(`${testPath}create`)
+        .send(mockAlreadyExistingRole)
+        .end((err, res) => {
+          expect(res.body).to.be.a('object');
+          expect(res.status).to.equal(400);
+          expect(res.body.message).to.equal('This role already exists');
+          done(err);
+        });
+    });
+  });
+});

--- a/tests/mocks/roles.mock.js
+++ b/tests/mocks/roles.mock.js
@@ -1,0 +1,15 @@
+const mockCreateRole = {
+  title: 'Member',
+};
+
+const mockRoleWithoutTitleField = {};
+
+const mockAlreadyExistingRole = {
+  title: 'User',
+};
+
+export {
+  mockCreateRole,
+  mockRoleWithoutTitleField,
+  mockAlreadyExistingRole
+};


### PR DESCRIPTION
#### What does this PR do?
- The scope of the application requires multiple users on the platform. This task is set up so multiple roles can be created.
#### Description of Task to be completed?
- User roles should be able to be created
- Only one instance of a role can exist
#### How should this be manually tested?
- Pull this branch `ft-create-user-roles-165165474`
- Send a post request to the endpoint `/api/v1/roles/create`
```
{
  title: 'Member'
}
```
#### What are the relevant pivotal tracker stories?
[#165165474](https://www.pivotaltracker.com/story/show/165165474)
#### Screenshots (if appropriate)
<img width="1195" alt="Screen Shot 2019-04-09 at 5 50 39 PM" src="https://user-images.githubusercontent.com/42177767/55819324-6da9b480-5af0-11e9-9e82-ecbf1bbe8d67.png">

*When a role is successfully created*

<img width="1195" alt="Screen Shot 2019-04-09 at 5 50 16 PM" src="https://user-images.githubusercontent.com/42177767/55819325-6da9b480-5af0-11e9-9af7-37060366b88e.png">

*When there is an attempt to insert an existing role*
